### PR TITLE
Fix the bug that the element can't be deleted in the function 'onLoad'.

### DIFF
--- a/me-lazyload.js
+++ b/me-lazyload.js
@@ -8,7 +8,11 @@ angular.module('me-lazyload', [])
         elements = {};
 
     function getUid(el){
-        return el.__uid || (el.__uid = '' + ++uid);
+        var __uid = el.data("__uid");
+        if (! __uid) {
+            el.data("__uid", (__uid = '' + ++uid));
+        }
+        return __uid;
     }
 
     function getWindowOffset(){


### PR DESCRIPTION
Hello Treri,  thanks for your 'me-lazyload'! It helps me a lot in my project. 

I came across a problem when I debugging my page. In the function 'onLoad', you get the target element wrapped by 'angular.element', and it won't have an attribute named "__uid" because it's new. So when calling 'getUid($el)', the element will be set with a new "__uid" instead of returning the expected one that was set in the 'link'. So, the judgement 'elements.hasOwnProperty(uid)' will always be unsuccessful.

My solution is saving the "__uid" as the element data in the function 'getUid'. Below is the crrection:
    function getUid(el){
        var __uid = el.data("__uid");
        if (! __uid) {
            el.data("__uid", (__uid = '' + ++uid));
        }
        return __uid;
    }

Thanks again, and excuse me for my awkward English.
